### PR TITLE
Compatibility addition to addon planes

### DIFF
--- a/itc_air/cfgVehicles.hpp
+++ b/itc_air/cfgVehicles.hpp
@@ -113,6 +113,7 @@ class cfgVehicles {
           };
         };
       };
+      class itc_air : itc_air_default_jet {};
     };
     class Plane_Fighter_04_Base_F : Plane_Base_F {
         class Components : Components {


### PR DESCRIPTION
add default code to Plane_Base_F class
by doing this, all addon planes (which uses Plane_Base_F as one of its base classes) will have minimun compatibilities for ITC features